### PR TITLE
cache sprite color to fix cascade premultiplyAlpha issue

### DIFF
--- a/engine/assemblers/assembler-2d.js
+++ b/engine/assemblers/assembler-2d.js
@@ -30,7 +30,6 @@ let _updateColor = cc.Assembler2D.prototype.updateColor;
 cc.Assembler2D.prototype.updateColor = function(comp, color) {
     this._dirtyPtr[0] |= cc.Assembler.FLAG_VERTICES_OPACITY_CHANGED;
     _updateColor.call(this, comp, color);
-
-    if (comp._assembler.cacheColor)
-        comp._assembler.cacheColor();
+    if (this.cacheColor)
+        this.cacheColor();
 };

--- a/engine/assemblers/assembler-2d.js
+++ b/engine/assemblers/assembler-2d.js
@@ -30,4 +30,7 @@ let _updateColor = cc.Assembler2D.prototype.updateColor;
 cc.Assembler2D.prototype.updateColor = function(comp, color) {
     this._dirtyPtr[0] |= cc.Assembler.FLAG_VERTICES_OPACITY_CHANGED;
     _updateColor.call(this, comp, color);
+
+    if (comp._assembler.cacheColor)
+        comp._assembler.cacheColor();
 };


### PR DESCRIPTION
When node color changed, cache node color in native Assembler.
Should implement cacheColor in cocos2d-x

[Related Issue]
https://github.com/cocos-creator/engine/issues/7830

[Related PR (cocos2d-x)]
to edit ..
